### PR TITLE
Use macOS destination in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,5 +20,4 @@ jobs:
         run: >-
           set -o pipefail && xcodebuild test \
             -scheme Keychain \
-            -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 14' | xcbeautify
+            -destination 'platform=macOS' | xcbeautify


### PR DESCRIPTION
The macOS destination is much faster, so use that instead of iOS.

If I end up using this module often I may start testing on a matrix of platforms and versions for better coverage.